### PR TITLE
Fixed a typo in the scan configuration name

### DIFF
--- a/ci-driven-scan-config-template.yml
+++ b/ci-driven-scan-config-template.yml
@@ -117,7 +117,7 @@ headersCookiesConfig:
 
 platformAuthentication:
   # Enter a list of additional platform authentication details
-  # - type: Choose from Basic, NTLM v1, or NTLM v2.
+  # - type: Choose from BASIC, NTLM v1, or NTLM v2.
   #   destinationHost: localhost
   #   username: username
   #   password: password
@@ -127,7 +127,7 @@ platformAuthentication:
 proxies:
   # Enter a list of proxy server configurations
   # - authentication:
-  #     type: Choose from None, Basic, NTLM v1, or NTLM v2.
+  #     type: Choose from None, BASIC, NTLM v1, or NTLM v2.
   #     username: username
   #     password: password
   #     domain: domain

--- a/ci-driven-scan-no-dash-config-template.yml
+++ b/ci-driven-scan-no-dash-config-template.yml
@@ -89,7 +89,7 @@ headersCookiesConfig:
 
 platformAuthentication:
   # Enter a list of additional platform authentication details
-  # - type: Choose from Basic, NTLM v1, or NTLM v2.
+  # - type: Choose from BASIC, NTLM v1, or NTLM v2.
   #   destinationHost: localhost
   #   username: username
   #   password: password
@@ -100,7 +100,7 @@ proxies:
   # Enter a list of proxy server configurations
   # proxies:
   # - authentication:
-  #     type: Choose from None, Basic, NTLM v1, or NTLM v2.
+  #     type: Choose from None, BASIC, NTLM v1, or NTLM v2.
   #     username: username
   #     password: password
   #     domain: domain


### PR DESCRIPTION
Hi,

I found there is a typo in the current version of the YAML templates.

As discussed in [the user forum](https://forum.portswigger.net/thread/enterprise-edition-unrecognised-field-in-config-file-section-platformauthentication-cb58096d), if I use `Basic` in `platformAuthentication.type` it causes the following error and the pipeline will be failed.

```
Unrecognised field in config file section: platformAuthentication
```

The value should be capitalized.

```diff
- type: Choose from None, Basic, NTLM v1, or NTLM v2.
+ type: Choose from None, BASIC, NTLM v1, or NTLM v2.
```

Thank you so much!